### PR TITLE
fix: Character encoding issues in mock response to handle non-ASCII characters correctly

### DIFF
--- a/lib/src/mock_supabase_http_client.dart
+++ b/lib/src/mock_supabase_http_client.dart
@@ -535,7 +535,7 @@ class MockSupabaseHttpClient extends BaseClient {
     return StreamedResponse(
       Stream.value(utf8.encode(jsonEncode(data))),
       statusCode,
-      headers: {'content-type': 'application/json'},
+      headers: {'content-type': 'application/json; charset=utf-8'},
       request: request,
     );
   }

--- a/test/mock_supabase_test.dart
+++ b/test/mock_supabase_test.dart
@@ -647,4 +647,20 @@ void main() {
       expect(posts[1]['comments'].first['content'], 'Fourth comment');
     });
   });
+
+  group('non-ASCII characters tests', () {
+    test('Insert Japanese text', () async {
+      await mockSupabase.from('posts').insert({'title': 'こんにちは'});
+      final posts = await mockSupabase.from('posts').select();
+      expect(posts.length, 1);
+      expect(posts.first, {'title': 'こんにちは'});
+    });
+
+    test('Insert emoji', () async {
+      await mockSupabase.from('posts').insert({'title': '😀'});
+      final posts = await mockSupabase.from('posts').select();
+      expect(posts.length, 1);
+      expect(posts.first, {'title': '😀'});
+    });
+  });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
This PR introduces a fix for character encoding issues in the mock response. Specifically, it addresses the problem of garbled characters by setting proper charset headers to handle non-ASCII characters, such as Japanese text, correctly.

## What is the current behavior?
```
await mockSupabase.from('test').insert({'test': 'こんにちは'});
final result = await mockSupabase.from('test').select();
````
The result contains garbled characters: [{test: ããã«ã¡ã¯}]

## What is the new behavior?
The result will correctly display the inserted Japanese text: [{test: こんにちは}], with proper character encoding.

---
I've also added tests for this change, but I'm not entirely confident that they cover everything. I would greatly appreciate it if you could review the PR and let me know if there are any additional considerations. Thank you!