### PR TITLE
Feat/handles datetime on lt filter

### DIFF
--- a/lib/src/mock_supabase_http_client.dart
+++ b/lib/src/mock_supabase_http_client.dart
@@ -543,7 +543,19 @@ class MockSupabaseHttpClient extends BaseClient {
       return (row) => row[columnName].toString() != value;
     } else if (postrestFilter.startsWith('gt.')) {
       final value = postrestFilter.substring(3);
-      return (row) => row[columnName] > num.tryParse(value);
+
+      if (DateTime.tryParse(value) != null) {
+        final dateTime = DateTime.parse(value);
+
+        return (row) {
+          final rowDate = DateTime.tryParse(row[columnName].toString());
+          return rowDate != null && rowDate.isAfter(dateTime);
+        };
+      } else if (num.tryParse(value) != null) {
+        return (row) => row[columnName] > num.tryParse(value);
+      } else {
+        throw UnimplementedError('Unsupported value type');
+      }
     } else if (postrestFilter.startsWith('lt.')) {
       final value = postrestFilter.substring(3);
       return (row) => row[columnName] < num.tryParse(value);

--- a/lib/src/mock_supabase_http_client.dart
+++ b/lib/src/mock_supabase_http_client.dart
@@ -558,7 +558,19 @@ class MockSupabaseHttpClient extends BaseClient {
       }
     } else if (postrestFilter.startsWith('lt.')) {
       final value = postrestFilter.substring(3);
-      return (row) => row[columnName] < num.tryParse(value);
+
+      if (DateTime.tryParse(value) != null) {
+        final dateTime = DateTime.parse(value);
+
+        return (row) {
+          final rowDate = DateTime.tryParse(row[columnName].toString());
+          return rowDate != null && rowDate.isBefore(dateTime);
+        };
+      } else if (num.tryParse(value) != null) {
+        return (row) => row[columnName] < num.tryParse(value);
+      } else {
+        throw UnimplementedError('Unsupported value type');
+      }
     } else if (postrestFilter.startsWith('gte.')) {
       final value = postrestFilter.substring(4);
       return (row) => row[columnName] >= num.tryParse(value);

--- a/test/mock_supabase_test.dart
+++ b/test/mock_supabase_test.dart
@@ -691,6 +691,32 @@ void main() {
       expect(count, 2);
     });
 
+    test('count with gt filter with datetime format', () async {
+      await mockSupabase.from('data').insert([
+        {
+          'title': 'First post',
+          'author_id': 1,
+          'createdAt': '2021-08-01 11:26:15.307+00'
+        },
+        {
+          'title': 'Second post',
+          'author_id': 2,
+          'createdAt': '2021-08-02 11:26:15.307+00'
+        },
+        {
+          'title': 'Third post',
+          'author_id': 1,
+          'createdAt': '2021-08-03 11:26:15.307+00'
+        }
+      ]);
+      final count = await mockSupabase
+          .from('data')
+          .count()
+          .gt('createdAt', '2021-08-02 10:26:15.307+00');
+
+      expect(count, 2);
+    });
+
     test('count with data and filter', () async {
       await mockSupabase.from('posts').insert([
         {'title': 'First post', 'author_id': 1},

--- a/test/mock_supabase_test.dart
+++ b/test/mock_supabase_test.dart
@@ -717,6 +717,32 @@ void main() {
       expect(count, 2);
     });
 
+    test('count with lt filter with datetime format', () async {
+      await mockSupabase.from('data').insert([
+        {
+          'title': 'First post',
+          'author_id': 1,
+          'createdAt': '2021-08-01 11:26:15.307+00'
+        },
+        {
+          'title': 'Second post',
+          'author_id': 2,
+          'createdAt': '2021-08-02 11:26:15.307+00'
+        },
+        {
+          'title': 'Third post',
+          'author_id': 1,
+          'createdAt': '2021-08-03 11:26:15.307+00'
+        }
+      ]);
+      final count = await mockSupabase
+          .from('data')
+          .count()
+          .lt('createdAt', '2021-08-02 12:26:15.307+00');
+
+      expect(count, 2);
+    });
+
     test('count with data and filter', () async {
       await mockSupabase.from('posts').insert([
         {'title': 'First post', 'author_id': 1},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add support to datetime on "lt." supabase filter

## What is the current behavior?

throws an error: NoSuchMethodError: The method '<' was called on null.

## What is the new behavior?

accepts datetime value type and int value type

## Additional context

none