### PR TITLE
feat: add functions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,140 @@ void main() {
 }
 ```
 
+### Mocking Edge Functions
+
+You can easily mock edge functions using the `registerEdgeFunction` method of `MockSupabaseHttpClient`. This method allows you to specify a handler function, giving you fine-grained control over the response based on the request body, HTTP method, and query parameters. You even have access to the mock database.
+
+```dart
+ group('Edge Functions Client', () {
+    test('invoke registered edge function with POST', () async {
+      mockHttpClient.registerEdgeFunction('greet',
+          (body, queryParams, method, tables) {
+        return FunctionResponse(
+          data: {'message': 'Hello, ${body['name']}!'},
+          status: 200,
+        );
+      });
+
+      final response = await mockSupabase.functions.invoke(
+        'greet',
+        body: {'name': 'Alice'},
+      );
+
+      expect(response.status, 200);
+      expect(response.data, {'message': 'Hello, Alice!'});
+    });
+
+    test('invoke edge function with different HTTP methods', () async {
+      mockHttpClient.registerEdgeFunction('say-hello',
+          (body, queryParams, method, tables) {
+        final name = switch (method) {
+          HttpMethod.patch => 'Linda',
+          HttpMethod.post => 'Bob',
+          _ => 'Unknown'
+        };
+        return FunctionResponse(
+          data: {'hello': name},
+          status: 200,
+        );
+      });
+
+      var patchResponse = await mockSupabase.functions
+          .invoke('say-hello', method: HttpMethod.patch);
+      expect(patchResponse.data, {'hello': 'Linda'});
+
+      var postResponse = await mockSupabase.functions
+          .invoke('say-hello', method: HttpMethod.post);
+      expect(postResponse.data, {'hello': 'Bob'});
+    });
+
+    test('edge function receives query params and body', () async {
+      mockHttpClient.registerEdgeFunction('params-test',
+          (body, queryParams, method, tables) {
+        final city = queryParams['city'];
+        final street = body['street'] as String;
+        return FunctionResponse(
+          data: {'address': '$street, $city'},
+          status: 200,
+        );
+      });
+
+      final response = await mockSupabase.functions.invoke(
+        'params-test',
+        body: {'street': '123 Main St'},
+        queryParameters: {'city': 'Springfield'},
+      );
+
+      expect(response.data, {'address': '123 Main St, Springfield'});
+    });
+
+    test('edge function returns different content types', () async {
+      mockHttpClient.registerEdgeFunction('binary',
+          (body, queryParams, method, tables) {
+        return FunctionResponse(
+          data: Uint8List.fromList([1, 2, 3]),
+          status: 200,
+        );
+      });
+
+      var response = await mockSupabase.functions.invoke('binary');
+      expect(response.data is Uint8List, true);
+      expect((response.data as Uint8List).length, 3);
+
+      mockHttpClient.registerEdgeFunction('text',
+          (body, queryParams, method, tables) {
+        return FunctionResponse(
+          data: 'Hello, world!',
+          status: 200,
+        );
+      });
+
+      response = await mockSupabase.functions.invoke('text');
+      expect(response.data, 'Hello, world!');
+
+      mockHttpClient.registerEdgeFunction('json',
+          (body, queryParams, method, tables) {
+        return FunctionResponse(
+          data: {'key': 'value'},
+          status: 200,
+        );
+      });
+
+      response = await mockSupabase.functions.invoke('json');
+      expect(response.data, {'key': 'value'});
+    });
+
+    test('edge function modifies mock database', () async {
+      mockHttpClient.registerEdgeFunction('add-user',
+          (body, queryParams, method, tables) {
+        final users = tables['public.users'] ?? [];
+        final newUser = {
+          'id': users.length + 1,
+          'name': body['name'],
+        };
+        users.add(newUser);
+        tables['public.users'] = users;
+        return FunctionResponse(data: newUser, status: 201);
+      });
+
+      var users = await mockSupabase.from('users').select();
+      expect(users, isEmpty);
+
+      final response = await mockSupabase.functions.invoke(
+        'add-user',
+        body: {'name': 'Alice'},
+      );
+      expect(response.status, 201);
+      expect(response.data, {'id': 1, 'name': 'Alice'});
+
+      users = await mockSupabase.from('users').select();
+      expect(users, [
+        {'id': 1, 'name': 'Alice'}
+      ]);
+    });
+  });
+```
+
 ### Mocking Errors
 
 You can simulate error scenarios by configuring an error trigger callback. This is useful for testing how your application handles various error conditions:

--- a/lib/src/mock_supabase_http_client.dart
+++ b/lib/src/mock_supabase_http_client.dart
@@ -51,6 +51,20 @@ import 'utils/filter_parser.dart';
 /// }
 /// ```
 ///
+/// You can mock edge functions using the [registerEdgeFunction] callback:
+/// ```dart
+/// final client = MockSupabaseHttpClient();
+/// client.registerEdgeFunction(
+///  'get_user_status',
+/// (body, queryParameters, method, tables) {
+///  return FunctionResponse(
+///   data: {'status': 'active'},
+///   status: 200,
+/// );
+///
+/// final response = await supabaseClient.functions.invoke('get_user_status');
+/// ```
+///
 /// You can simulate errors using the [postgrestExceptionTrigger] callback:
 /// ```dart
 /// final client = MockSupabaseHttpClient(
@@ -823,15 +837,17 @@ class MockSupabaseHttpClient extends BaseClient {
     );
   }
 
-  /// Registers a response for a specific function name.
+  /// Registers an edge function with the given name and handler.
   ///
-  /// This method allows you to associate a [FunctionResponse] with a given
-  /// [functionName]. The registered response can later be retrieved or used
-  /// when the function is called.
+  /// The [name] parameter specifies the name of the edge function.
   ///
-  /// - Parameters:
-  ///   - functionName: The name of the function to register the response for.
-  ///   - response: The [FunctionResponse] to be associated with the function name.
+  /// The [handler] parameter is a function that takes the following parameters:
+  /// - [body]: A map containing the body of the request.
+  /// - [queryParameters]: A map containing the query parameters of the request.
+  /// - [method]: The HTTP method of the request.
+  /// - [tables]: A map containing lists of maps representing the tables involved in the request.
+  ///
+  /// The [handler] function should return a [FunctionResponse].
   void registerEdgeFunction(
     String name,
     FunctionResponse Function(

--- a/test/mock_supabase_http_client_test.dart
+++ b/test/mock_supabase_http_client_test.dart
@@ -1,5 +1,4 @@
-import 'dart:async';
-import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:mock_supabase_http_client/mock_supabase_http_client.dart';
 import 'package:supabase/supabase.dart';
@@ -1158,21 +1157,142 @@ void main() {
     });
   });
 
-  group("Edge functions", () {
-    test('Test function invocation', () async {
-      mockHttpClient.registerFunctionResponse(
-        'hello',
-        FunctionResponse(data: {'message': 'Hello'}, status: 200),
+  group('Edge Functions Client', () {
+    test('invoke registered edge function with POST', () async {
+      mockHttpClient.registerEdgeFunction('greet',
+          (body, queryParams, method, tables) {
+        return FunctionResponse(
+          data: {'message': 'Hello, ${body['name']}!'},
+          status: 200,
+        );
+      });
+
+      final response = await mockSupabase.functions.invoke(
+        'greet',
+        body: {'name': 'Alice'},
       );
 
-      final response = await mockSupabase.functions.invoke('hello');
-      expect(response.data, {'message': 'Hello'});
       expect(response.status, 200);
+      expect(response.data, {'message': 'Hello, Alice!'});
     });
 
-    test("invocation failes if function not found", () async {
-      expect(() => mockSupabase.functions.invoke('non_existent_function'),
-          throwsA(isA<FunctionException>()));
+    test('invoke edge function with different HTTP methods', () async {
+      mockHttpClient.registerEdgeFunction('say-hello',
+          (body, queryParams, method, tables) {
+        final name = switch (method) {
+          HttpMethod.patch => 'Linda',
+          HttpMethod.post => 'Bob',
+          _ => 'Unknown'
+        };
+        return FunctionResponse(
+          data: {'hello': name},
+          status: 200,
+        );
+      });
+
+      var patchResponse = await mockSupabase.functions
+          .invoke('say-hello', method: HttpMethod.patch);
+      expect(patchResponse.data, {'hello': 'Linda'});
+
+      var postResponse = await mockSupabase.functions
+          .invoke('say-hello', method: HttpMethod.post);
+      expect(postResponse.data, {'hello': 'Bob'});
+    });
+
+    test('edge function receives query params and body', () async {
+      mockHttpClient.registerEdgeFunction('params-test',
+          (body, queryParams, method, tables) {
+        final city = queryParams['city'];
+        final street = body['street'] as String;
+        return FunctionResponse(
+          data: {'address': '$street, $city'},
+          status: 200,
+        );
+      });
+
+      final response = await mockSupabase.functions.invoke(
+        'params-test',
+        body: {'street': '123 Main St'},
+        queryParameters: {'city': 'Springfield'},
+      );
+
+      expect(response.data, {'address': '123 Main St, Springfield'});
+    });
+
+    test('edge function returns different content types', () async {
+      mockHttpClient.registerEdgeFunction('binary',
+          (body, queryParams, method, tables) {
+        return FunctionResponse(
+          data: Uint8List.fromList([1, 2, 3]),
+          status: 200,
+        );
+      });
+
+      var response = await mockSupabase.functions.invoke('binary');
+      expect(response.data is Uint8List, true);
+      expect((response.data as Uint8List).length, 3);
+
+      mockHttpClient.registerEdgeFunction('text',
+          (body, queryParams, method, tables) {
+        return FunctionResponse(
+          data: 'Hello, world!',
+          status: 200,
+        );
+      });
+
+      response = await mockSupabase.functions.invoke('text');
+      expect(response.data, 'Hello, world!');
+
+      mockHttpClient.registerEdgeFunction('json',
+          (body, queryParams, method, tables) {
+        return FunctionResponse(
+          data: {'key': 'value'},
+          status: 200,
+        );
+      });
+
+      response = await mockSupabase.functions.invoke('json');
+      expect(response.data, {'key': 'value'});
+    });
+
+    test('invoke non-existent edge function returns 404', () async {
+      expect(
+        () async => await mockSupabase.functions.invoke('not-found'),
+        throwsA(isA<FunctionException>().having(
+          (e) => e.status,
+          'statusCode',
+          404,
+        )),
+      );
+    });
+
+    test('edge function modifies mock database', () async {
+      mockHttpClient.registerEdgeFunction('add-user',
+          (body, queryParams, method, tables) {
+        final users = tables['public.users'] ?? [];
+        final newUser = {
+          'id': users.length + 1,
+          'name': body['name'],
+        };
+        users.add(newUser);
+        tables['public.users'] = users;
+        return FunctionResponse(data: newUser, status: 201);
+      });
+
+      var users = await mockSupabase.from('users').select();
+      expect(users, isEmpty);
+
+      final response = await mockSupabase.functions.invoke(
+        'add-user',
+        body: {'name': 'Alice'},
+      );
+      expect(response.status, 201);
+      expect(response.data, {'id': 1, 'name': 'Alice'});
+
+      users = await mockSupabase.from('users').select();
+      expect(users, [
+        {'id': 1, 'name': 'Alice'}
+      ]);
     });
   });
 }

--- a/test/mock_supabase_http_client_test.dart
+++ b/test/mock_supabase_http_client_test.dart
@@ -1295,6 +1295,8 @@ void main() {
       expect(users, [
         {'id': 1, 'name': 'Alice'}
       ]);
+    });
+  });
 
   group('mock exceptions', () {
     group('basic operation exceptions', () {

--- a/test/mock_supabase_http_client_test.dart
+++ b/test/mock_supabase_http_client_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:mock_supabase_http_client/mock_supabase_http_client.dart';
 import 'package:supabase/supabase.dart';
 import 'package:test/test.dart';
@@ -1152,6 +1155,24 @@ void main() {
           .eq('id', 1)
           .single();
       expect(customUser, containsPair('points', 50));
+    });
+  });
+
+  group("Edge functions", () {
+    test('Test function invocation', () async {
+      mockHttpClient.registerFunctionResponse(
+        'hello',
+        FunctionResponse(data: {'message': 'Hello'}, status: 200),
+      );
+
+      final response = await mockSupabase.functions.invoke('hello');
+      expect(response.data, {'message': 'Hello'});
+      expect(response.status, 200);
+    });
+
+    test("invocation failes if function not found", () async {
+      expect(() => mockSupabase.functions.invoke('non_existent_function'),
+          throwsA(isA<FunctionException>()));
     });
   });
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Currently, function invocation is not supported.

## What is the new behavior?

This PR adds a new method to the `MockSupabaseHttpClient`: you can now call the `registerFunctionsResponse` function, which registers a new function. As function parameters, you can specify a name and a `FunctionResponse` object. This function can now be called, e.g. using `Supabase.instance.client.functions.invoke`