### PR TITLE
feat: Add support for triggering error for PostgREST methods. 

### DIFF
--- a/lib/src/mock_supabase_http_client.dart
+++ b/lib/src/mock_supabase_http_client.dart
@@ -13,6 +13,26 @@ class MockSupabaseHttpClient extends BaseClient {
       dynamic Function(Map<String, dynamic>? params,
           Map<String, List<Map<String, dynamic>>> tables)> _rpcFunctions = {};
 
+  /// A function that can be used to trigger errors.
+  ///
+  /// Throw a PostgrestException within the `errorTrigger` to mock an error.
+  ///
+  /// Example:
+  /// ```dart
+  /// final client = MockSupabaseHttpClient(
+  ///   errorTrigger: (schema, table, data, type) {
+  ///     if (table == 'users' && type == RequestType.insert) {
+  ///       throw PostgrestException(
+  ///         message: 'Email already exists', // Provide a message
+  ///         code: '400', // Optionally provide a status code
+  ///         details: 'Key (email)=(test@test.com) already exists', // Optionally provide details
+  ///         hint: 'Change the email address', // Optionally provide a hint
+  ///       );
+  ///     }
+  ///     // The request will succeed otherwise
+  ///   },
+  /// );
+  /// ```
   final void Function(
     String schema,
     String? table,
@@ -28,6 +48,7 @@ class MockSupabaseHttpClient extends BaseClient {
     _rpcHandler = RpcHandler(_rpcFunctions, _database);
   }
 
+  /// Clears the mock database and RPC functions.
   void reset() {
     // Clear the mock database and RPC functions
     _database.clear();

--- a/lib/src/mock_supabase_http_client.dart
+++ b/lib/src/mock_supabase_http_client.dart
@@ -295,9 +295,6 @@ class MockSupabaseHttpClient extends BaseClient {
             schema, table, request.url.queryParameters, request);
       case RequestType.head:
         return _handleHead(schema, table, request.url.queryParameters, request);
-      default:
-        return _createResponse({'error': 'Method not allowed'},
-            statusCode: 405, request: request);
     }
   }
 

--- a/test/mock_supabase_http_client_test.dart
+++ b/test/mock_supabase_http_client_test.dart
@@ -1161,7 +1161,7 @@ void main() {
     group('basic operation exceptions', () {
       test('select throws PostgrestException', () async {
         mockHttpClient = MockSupabaseHttpClient(
-          errorTrigger: (schema, table, data, type) {
+          postgrestExceptionTrigger: (schema, table, data, type) {
             if (type == RequestType.select) {
               throw PostgrestException(
                 code: '400',
@@ -1188,7 +1188,7 @@ void main() {
 
       test('insert throws PostgrestException', () async {
         mockHttpClient = MockSupabaseHttpClient(
-          errorTrigger: (schema, table, data, type) {
+          postgrestExceptionTrigger: (schema, table, data, type) {
             if (type == RequestType.insert) {
               throw PostgrestException(
                 code: '409',
@@ -1215,7 +1215,7 @@ void main() {
 
       test('update throws PostgrestException', () async {
         mockHttpClient = MockSupabaseHttpClient(
-          errorTrigger: (schema, table, data, type) {
+          postgrestExceptionTrigger: (schema, table, data, type) {
             if (type == RequestType.update) {
               throw PostgrestException(
                 code: '404',
@@ -1244,7 +1244,7 @@ void main() {
 
       test('delete throws PostgrestException', () async {
         mockHttpClient = MockSupabaseHttpClient(
-          errorTrigger: (schema, table, data, type) {
+          postgrestExceptionTrigger: (schema, table, data, type) {
             if (type == RequestType.delete) {
               throw PostgrestException(
                 code: '403',
@@ -1271,7 +1271,7 @@ void main() {
 
       test('upsert throws PostgrestException', () async {
         mockHttpClient = MockSupabaseHttpClient(
-          errorTrigger: (schema, table, data, type) {
+          postgrestExceptionTrigger: (schema, table, data, type) {
             if (type == RequestType.upsert) {
               throw PostgrestException(
                 code: '422',
@@ -1298,7 +1298,7 @@ void main() {
 
       test('rpc throws PostgrestException', () async {
         mockHttpClient = MockSupabaseHttpClient(
-          errorTrigger: (schema, table, data, type) {
+          postgrestExceptionTrigger: (schema, table, data, type) {
             if (type == RequestType.rpc) {
               throw PostgrestException(
                 code: '500',
@@ -1327,7 +1327,7 @@ void main() {
     group('conditional exceptions', () {
       test('throws when age is negative', () async {
         mockHttpClient = MockSupabaseHttpClient(
-          errorTrigger: (schema, table, data, type) {
+          postgrestExceptionTrigger: (schema, table, data, type) {
             if (type == RequestType.insert && data is Map) {
               if (data['age'] != null && data['age'] < 0) {
                 throw PostgrestException(
@@ -1356,7 +1356,7 @@ void main() {
 
       test('throws when email is invalid', () async {
         mockHttpClient = MockSupabaseHttpClient(
-          errorTrigger: (schema, table, data, type) {
+          postgrestExceptionTrigger: (schema, table, data, type) {
             if ((type == RequestType.insert || type == RequestType.update) &&
                 data is Map) {
               if (data['email'] != null && !data['email'].contains('@')) {
@@ -1388,7 +1388,7 @@ void main() {
 
       test('throws when table does not exist', () async {
         mockHttpClient = MockSupabaseHttpClient(
-          errorTrigger: (schema, table, data, type) {
+          postgrestExceptionTrigger: (schema, table, data, type) {
             if (table == 'non_existent_table') {
               throw PostgrestException(
                 code: '404',
@@ -1415,7 +1415,7 @@ void main() {
 
       test('throws when schema does not exist', () async {
         mockHttpClient = MockSupabaseHttpClient(
-          errorTrigger: (schema, table, data, type) {
+          postgrestExceptionTrigger: (schema, table, data, type) {
             if (schema == 'non_existent_schema') {
               throw PostgrestException(
                 code: '404',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds support to emulate errors. 

## What is the current behavior?

There are no way to emulate errors.

## What is the new behavior?

You can emulate PostgrestExceptions with the `postgrestExceptionTrigger` parameter.

```dart
mockHttpClient = MockSupabaseHttpClient(
  postgrestExceptionTrigger: (schema, table, data, type) {
    // Simulate unique constraint violation on email
    if (table == 'users' && type == RequestType.insert) {
      throw PostgrestException(
        message: 'duplicate key value violates unique constraint "users_email_key"',
        code: '23505', // Postgres unique violation code
      );
    }
    
    // Simulate permission error for certain operations
    if (table == 'private_data' && type == RequestType.select) {
      throw PostgrestException(
        message: 'permission denied for table private_data',
        code: '42501', // Postgres permission denied code
      );
    }
  },
);
```
