### PR TITLE
Bugfix/issue 16 error on select after delete or update

### DIFF
--- a/lib/src/mock_supabase_http_client.dart
+++ b/lib/src/mock_supabase_http_client.dart
@@ -373,18 +373,22 @@ class MockSupabaseHttpClient extends BaseClient {
     final queryParams = request.url.queryParameters;
     var updated = false;
 
+    // Track updated rows
+    final updatedRows = [];
+
     // Update items that match the filters
     if (_database.containsKey(tableKey)) {
       for (var row in _database[tableKey]!) {
         if (_matchesFilters(row: row, filters: queryParams)) {
           row.addAll(data);
           updated = true;
+          updatedRows.add(row);
         }
       }
     }
 
     if (updated) {
-      return _createResponse(data, request: request);
+      return _createResponse(updatedRows, request: request);
     } else {
       return _createResponse({'error': 'Not found'},
           statusCode: 404, request: request);

--- a/lib/src/mock_supabase_http_client.dart
+++ b/lib/src/mock_supabase_http_client.dart
@@ -338,9 +338,10 @@ class MockSupabaseHttpClient extends BaseClient {
     if (!_database.containsKey(tableKey)) {
       _database[tableKey] = [];
     }
+
     if (data is Map<String, dynamic>) {
       _database[tableKey]!.add(data);
-      return _createResponse(data, request: request);
+      return _createResponse([data], request: request);
     } else if (data is List) {
       final List<Map<String, dynamic>> items =
           List<Map<String, dynamic>>.from(data);

--- a/lib/src/mock_supabase_http_client.dart
+++ b/lib/src/mock_supabase_http_client.dart
@@ -468,12 +468,18 @@ class MockSupabaseHttpClient extends BaseClient {
           statusCode: 400, request: request);
     }
 
+    List removedItems = [];
     if (_database.containsKey(tableKey)) {
-      _database[tableKey]!.removeWhere(
-          (row) => _matchesFilters(row: row, filters: queryParams));
+      _database[tableKey]!.removeWhere((row) {
+        final matched = _matchesFilters(row: row, filters: queryParams);
+        if (matched) {
+          removedItems.add(row);
+        }
+        return matched;
+      });
     }
 
-    return _createResponse({'message': 'Deleted'}, request: request);
+    return _createResponse(removedItems, request: request);
   }
 
   StreamedResponse _handleSelect(

--- a/test/mock_supabase_http_client_test.dart
+++ b/test/mock_supabase_http_client_test.dart
@@ -92,9 +92,11 @@ void main() {
       await mockSupabase
           .from('posts')
           .insert({'id': 1, 'title': 'To be deleted'});
-      final posts =
+      final deleted =
           await mockSupabase.from('posts').delete().eq('id', 1).select();
-      expect(posts.length, 1);
+      expect(deleted.length, 1);
+      final posts = await mockSupabase.from('posts').select();
+      expect(posts.length, 0);
     });
 
     test('Select all columns', () async {

--- a/test/mock_supabase_http_client_test.dart
+++ b/test/mock_supabase_http_client_test.dart
@@ -63,6 +63,20 @@ void main() {
       expect(posts.first, {'id': 1, 'title': 'Updated title'});
     });
 
+    test('Update then select', () async {
+      // Test updating a record
+      await mockSupabase
+          .from('posts')
+          .insert({'id': 1, 'title': 'Original title'});
+      final posts = await mockSupabase
+          .from('posts')
+          .update({'title': 'Updated title'})
+          .eq('id', 1)
+          .select();
+      expect(posts.length, 1);
+      expect(posts.first, {'id': 1, 'title': 'Updated title'});
+    });
+
     test('Delete', () async {
       // Test deleting a record
       await mockSupabase

--- a/test/mock_supabase_http_client_test.dart
+++ b/test/mock_supabase_http_client_test.dart
@@ -50,6 +50,20 @@ void main() {
       expect(postsUfterUpdate.first, {'id': 1, 'title': 'Updated post'});
     });
 
+    test('Upsert then select', () async {
+      // Test upserting a record
+      await mockSupabase
+          .from('posts')
+          .upsert({'id': 1, 'title': 'Initial post'});
+      final posts = await mockSupabase.from('posts').select();
+      expect(posts.first, {'id': 1, 'title': 'Initial post'});
+      final postsAfterUpdate = await mockSupabase
+          .from('posts')
+          .upsert({'id': 1, 'title': 'Updated post'}).select();
+      expect(postsAfterUpdate.length, 1);
+      expect(postsAfterUpdate.first, {'id': 1, 'title': 'Updated post'});
+    });
+
     test('Update', () async {
       // Test updating a record
       await mockSupabase

--- a/test/mock_supabase_http_client_test.dart
+++ b/test/mock_supabase_http_client_test.dart
@@ -86,6 +86,17 @@ void main() {
       final posts = await mockSupabase.from('posts').select();
       expect(posts.length, 0);
     });
+
+    test('Delete then select', () async {
+      // Test deleting a record
+      await mockSupabase
+          .from('posts')
+          .insert({'id': 1, 'title': 'To be deleted'});
+      final posts =
+          await mockSupabase.from('posts').delete().eq('id', 1).select();
+      expect(posts.length, 1);
+    });
+
     test('Select all columns', () async {
       // Test selecting all records
       await mockSupabase.from('posts').insert([

--- a/test/mock_supabase_http_client_test.dart
+++ b/test/mock_supabase_http_client_test.dart
@@ -35,6 +35,15 @@ void main() {
       expect(posts.first, {'title': 'Hello, world!'});
     });
 
+    test('Insert then select', () async {
+      // Test inserting a record
+      final posts = await mockSupabase
+          .from('posts')
+          .insert({'title': 'Hello, world!'}).select();
+      expect(posts.length, 1);
+      expect(posts.first, {'title': 'Hello, world!'});
+    });
+
     test('Upsert', () async {
       // Test upserting a record
       await mockSupabase


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR ensures that fetching records after insert, update and delete using `select` work as expected.

## What is the current behavior?

See Issue #16 

## What is the new behavior?

The insert, update and delete operations all function as expected when trailed by select .
