### PR TITLE
fix: onConflict parameter ignored in upsert

### DIFF
--- a/test/mock_supabase_http_client_test.dart
+++ b/test/mock_supabase_http_client_test.dart
@@ -77,7 +77,6 @@ void main() {
           );
       final usersAfterUpdate =
           await mockSupabase.from(table).select().eq('user_id', 1);
-      print(usersAfterUpdate.length);
       expect(usersAfterUpdate.length, 1);
       expect(usersAfterUpdate.first, updatedData);
     });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

Fixes #19 

## What is the current behavior?

See #19

## What is the new behavior?

`onConflict` parameter now respected during an upsert
