### PR TITLE
bugfix: selecting-with-filter-on-empty-table

### DIFF
--- a/lib/src/mock_supabase_http_client.dart
+++ b/lib/src/mock_supabase_http_client.dart
@@ -541,7 +541,7 @@ class MockSupabaseHttpClient extends BaseClient {
           }).toList();
         } else if (key.contains('!inner')) {
           // referenced table filtering with !inner
-        } else {
+        } else if (returningRows.isNotEmpty) {
           // Regular filtering on the top level table
           final filter = FilterParser.parseFilter(
             columnName: key,

--- a/lib/src/mock_supabase_http_client.dart
+++ b/lib/src/mock_supabase_http_client.dart
@@ -499,6 +499,9 @@ class MockSupabaseHttpClient extends BaseClient {
 
     // Handle basic filtering
     queryParams.forEach((key, value) {
+      if (returningRows.isEmpty) {
+        return;
+      }
       if (key != 'select' &&
           key != 'order' &&
           key != 'limit' &&
@@ -541,7 +544,7 @@ class MockSupabaseHttpClient extends BaseClient {
           }).toList();
         } else if (key.contains('!inner')) {
           // referenced table filtering with !inner
-        } else if (returningRows.isNotEmpty) {
+        } else {
           // Regular filtering on the top level table
           final filter = FilterParser.parseFilter(
             columnName: key,

--- a/test/mock_supabase_http_client_test.dart
+++ b/test/mock_supabase_http_client_test.dart
@@ -122,6 +122,16 @@ void main() {
       expect(posts.length, 0);
     });
 
+    test('Select after deleting all items', () async {
+      // Insert an item
+      await mockSupabase
+          .from('posts')
+          .insert({'id': 1, 'title': 'To be deleted'});
+      await mockSupabase.from('posts').delete().eq('id', 1);
+      final posts = await mockSupabase.from('posts').select().eq('id', 1);
+      expect(posts.length, 0);
+    });
+
     test('Select all columns', () async {
       // Test selecting all records
       await mockSupabase.from('posts').insert([
@@ -253,16 +263,6 @@ void main() {
       expect(titlesOnly.length, 2);
       expect(titlesOnly[0], {'id': 2, 'title': 'Second post'});
       expect(titlesOnly[1], {'id': 1, 'title': 'First post'});
-    });
-
-    test('Select after deleting all items', () async {
-      // Insert an item
-      await mockSupabase
-          .from('posts')
-          .insert({'id': 1, 'title': 'To be deleted'});
-      await mockSupabase.from('posts').delete().eq('id', 1);
-      final posts = await mockSupabase.from('posts').select().eq('id', 1);
-      expect(posts.length, 0);
     });
 
     test('No mixing with default schema', () async {

--- a/test/mock_supabase_http_client_test.dart
+++ b/test/mock_supabase_http_client_test.dart
@@ -255,6 +255,16 @@ void main() {
       expect(titlesOnly[1], {'id': 1, 'title': 'First post'});
     });
 
+    test('Select after deleting all items', () async {
+      // Insert an item
+      await mockSupabase
+          .from('posts')
+          .insert({'id': 1, 'title': 'To be deleted'});
+      await mockSupabase.from('posts').delete().eq('id', 1);
+      final posts = await mockSupabase.from('posts').select().eq('id', 1);
+      expect(posts.length, 0);
+    });
+
     test('No mixing with default schema', () async {
       // Insert into custom schema
       await mockSupabase

--- a/test/mock_supabase_http_client_test.dart
+++ b/test/mock_supabase_http_client_test.dart
@@ -132,6 +132,34 @@ void main() {
       expect(posts.length, 0);
     });
 
+    test('Select with a referenced table filter after deleting all items',
+        () async {
+      // Insert an item
+      await mockSupabase.from('posts').insert({
+        'id': 1,
+        'title': 'To be deleted',
+        'authors': {'id': 1, 'name': 'Author One'}
+      });
+      await mockSupabase.from('posts').delete().eq('id', 1);
+      final posts = await mockSupabase
+          .from('posts')
+          .select('*, authors(*)')
+          .eq('authors.name', 'Author One');
+      expect(posts.length, 0);
+    });
+
+    test('Select with chained filters where the first returns no rows',
+        () async {
+      // Insert an item
+      await mockSupabase.from('posts').insert({'id': 1, 'title': 'First post'});
+      final posts = await mockSupabase
+          .from('posts')
+          .select()
+          .eq('id', 2)
+          .eq('title', 'First post');
+      expect(posts.length, 0);
+    });
+
     test('Select all columns', () async {
       // Test selecting all records
       await mockSupabase.from('posts').insert([


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

Fixes #21

## What is the current behavior?

See #21

## What is the new behavior?

An empty array is returned if table is empty preventing error.
