### PR TITLE
fix(inFilter): Enable inFilter usage with strings

### DIFF
--- a/lib/src/utils/filter_parser.dart
+++ b/lib/src/utils/filter_parser.dart
@@ -68,7 +68,11 @@ class FilterParser {
       return (row) => row[columnName] == null;
     } else if (postrestFilter.startsWith('in.')) {
       final value = postrestFilter.substring(3);
-      final values = value.substring(1, value.length - 1).split(',');
+      final values =
+        value.substring(1, value.length - 1)
+             .split(',')
+             .map((e) => e.replaceAll(RegExp(r'^"|"$'), ''))
+             .toList();
       return (row) => values.contains(row[columnName].toString());
     } else if (postrestFilter.startsWith('cs.')) {
       final value = postrestFilter.substring(3);

--- a/lib/src/utils/filter_parser.dart
+++ b/lib/src/utils/filter_parser.dart
@@ -68,11 +68,7 @@ class FilterParser {
       return (row) => row[columnName] == null;
     } else if (postrestFilter.startsWith('in.')) {
       final value = postrestFilter.substring(3);
-      final values =
-        value.substring(1, value.length - 1)
-             .split(',')
-             .map((e) => e.replaceAll(RegExp(r'^"|"$'), ''))
-             .toList();
+      final values = _parseList(value.substring(1, value.length - 1));
       return (row) => values.contains(row[columnName].toString());
     } else if (postrestFilter.startsWith('cs.')) {
       final value = postrestFilter.substring(3);
@@ -121,6 +117,33 @@ class FilterParser {
       return (row) => !filter(row);
     }
     return (row) => true;
+  }
+
+  /// Splits the body of a Postgrest list on the commas that separate its
+  /// elements, then unquotes and unescapes each element.
+  ///
+  /// Postgrest quotes any element that is not a bare number and escapes `\`
+  /// and `"` inside it, so a naive split on commas would break on values that
+  /// contain a comma or a quote.
+  static List<String> _parseList(String body) {
+    final values = <String>[];
+    final buffer = StringBuffer();
+    var insideQuotes = false;
+    for (var index = 0; index < body.length; index++) {
+      final character = body[index];
+      if (character == '\\' && insideQuotes && index + 1 < body.length) {
+        buffer.write(body[++index]);
+      } else if (character == '"') {
+        insideQuotes = !insideQuotes;
+      } else if (character == ',' && !insideQuotes) {
+        values.add(buffer.toString());
+        buffer.clear();
+      } else {
+        buffer.write(character);
+      }
+    }
+    values.add(buffer.toString());
+    return values;
   }
 
   /// Handles comparison operations for date and numeric values.

--- a/test/mock_supabase_http_client_test.dart
+++ b/test/mock_supabase_http_client_test.dart
@@ -380,6 +380,10 @@ void main() {
       final posts =
           await mockSupabase.from('posts').select().inFilter('id', [1, 2]);
       expect(posts.length, 2);
+
+      final strPosts =
+          await mockSupabase.from('posts').select().inFilter('title', ["First post"]);
+      expect(strPosts.length, 1);
     });
     group('Not filters', () {
       setUp(() async {

--- a/test/mock_supabase_http_client_test.dart
+++ b/test/mock_supabase_http_client_test.dart
@@ -380,10 +380,40 @@ void main() {
       final posts =
           await mockSupabase.from('posts').select().inFilter('id', [1, 2]);
       expect(posts.length, 2);
+    });
 
-      final strPosts =
-          await mockSupabase.from('posts').select().inFilter('title', ["First post"]);
-      expect(strPosts.length, 1);
+    test('Filter by in with string values', () async {
+      await mockSupabase.from('posts').insert([
+        {'id': 1, 'title': 'First post'},
+        {'id': 2, 'title': 'Second post'}
+      ]);
+      final posts = await mockSupabase
+          .from('posts')
+          .select()
+          .inFilter('title', ['First post']);
+      expect(posts.length, 1);
+    });
+
+    test('Filter by in with a value containing a comma', () async {
+      await mockSupabase.from('posts').insert([
+        {'id': 1, 'title': 'Hello, world'},
+        {'id': 2, 'title': 'Second post'}
+      ]);
+      final posts = await mockSupabase
+          .from('posts')
+          .select()
+          .inFilter('title', ['Hello, world']);
+      expect(posts.length, 1);
+    });
+
+    test('Filter by in with a value containing a double quote', () async {
+      await mockSupabase.from('posts').insert([
+        {'id': 1, 'title': 'a"b'},
+        {'id': 2, 'title': 'Second post'}
+      ]);
+      final posts =
+          await mockSupabase.from('posts').select().inFilter('title', ['a"b']);
+      expect(posts.length, 1);
     });
     group('Not filters', () {
       setUp(() async {


### PR DESCRIPTION
## Commit Message

```
commit 8a4418443ca4da09781dc8c91117cc0f19e1c298 (HEAD -> main, origin/main, origin/HEAD)
Author: Thaddeus Diamond
Date:   Sun May 18 00:34:10 2025 -0500

[Purpose]
Enable inFilter in test environments when the filter is a string.

[Technical]
- Strip quotations passed from client side HTTP call (e.g., PostgREST)
- Add unit testing to validate

[ Testing: flutter test ]
```

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Unit tests for string filters in Flutter code like this fail:

```dart
final response = await _client
        .from('my_table')
        .select()
        .inFilter('filter_col', ['filter val 1', 'filter val 2']);
```

## What is the new behavior?

Strip (left and right) double quotations passed across HTTP wire.

## Additional context

See unit tests
