### PR TITLE
docs: audit the current limitations list

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ final mockSupabase = SupabaseClient(
 - Add mock data to the mock Supabase client
 - Supports select, insert, update, upsert, and delete operations
 - Supports filtering, ordering, and limiting results
+- Supports count and head requests
 - Supports referenced table operations
 - Can reset the mock data between tests
 
@@ -421,11 +422,10 @@ void main() {
     ```
 - `!inner` join is not supported.
 - Renaming column names is not supported.
-- count and head requests are not supported.
 - aggregate functions are not supported.
-- Respect nullsFirst on ordering is not supported.
+- `nullsFirst` on ordering is not supported. Ordering by a column that contains `null` throws instead of sorting.
 - The errors thrown by the mock Supabase client is not the same as the actual Supabase client.
-- The mock Supabase client does not support auth, realtime or storage.
+- The mock Supabase client does not support auth, realtime, or storage.
     - You can either mock those using libraries like [mockito](https://pub.dev/packages/mockito) or use the Supabase CLI to do a full integration testing. You could use our [GitHub actions](https://github.com/supabase/setup-cli) to do that.
 
 We will work on adding more features to the mock Supabase client to make it more feature complete.


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Following up on #23, the rest of the limitations list had not been audited against the code. I verified every bullet empirically by driving the mock client through a `SupabaseClient`, and found one stale entry plus two wording issues.

- `count and head requests are not supported.` is stale. `_handleHead` and the `count=` `Prefer` header handling make both work, and there is already a `count` test group covering it. A `HEAD`-only `.count(CountOption.exact)` returns the right number.
- `Respect nullsFirst on ordering is not supported.` is accurate but undersells it. The order parameter arrives as `column.asc.nullslast`, and the mock only reads the first two segments, so `nullsFirst` is ignored. Worse, ordering by a column containing `null` throws `type 'Null' is not a subtype of type 'num' of 'other'` rather than sorting.
- The serial comma in the auth/realtime/storage bullet was dropped in #23.

## What is the new behavior?

- Removed the count/head limitation and added a matching bullet to the features list, since that support was otherwise undocumented.
- Reworded the `nullsFirst` bullet to say it is ignored and that a nullable column throws.
- Restored the serial comma.

I re-verified that the remaining bullets are all still true, so they are untouched:

| Limitation | Verified behavior |
| --- | --- |
| Nested referenced tables | still unsupported |
| `!inner` join | the `!inner` branch is an empty no-op, so the row is returned with the referenced table set to `null` instead of being excluded |
| Renaming column names | `select('headline:title')` returns `[{}]` |
| aggregate functions | `select('score.sum()')` returns `[{}, {}]` |
| auth, realtime, storage | no handling anywhere in the client |

Docs only, no code change. `dart analyze` is clean and all 90 tests pass.