### PR TITLE
fix: honor ignoreDuplicates in upsert

### DIFF
--- a/lib/src/mock_supabase_http_client.dart
+++ b/lib/src/mock_supabase_http_client.dart
@@ -270,7 +270,8 @@ class MockSupabaseHttpClient extends BaseClient {
     } else if (request.method == 'POST') {
       final preferHeader = request.headers['Prefer'];
       if (preferHeader != null &&
-          preferHeader.contains('resolution=merge-duplicates')) {
+          (preferHeader.contains('resolution=merge-duplicates') ||
+              preferHeader.contains('resolution=ignore-duplicates'))) {
         requestType = RequestType.upsert;
       } else {
         requestType = RequestType.insert;
@@ -478,30 +479,41 @@ class MockSupabaseHttpClient extends BaseClient {
             .map((e) => e.trim())
             .toList();
 
+    // Rows that conflict are left untouched when the caller asked for
+    // `ignoreDuplicates`, and merged into otherwise
+    final ignoreDuplicates =
+        request.headers['Prefer']?.contains('resolution=ignore-duplicates') ??
+            false;
+
     // Upsert each item
-    final results = items.map((item) {
+    final results = <Map<String, dynamic>>[];
+    for (final item in items) {
       // Check if all onConflictColumns are set in item
-      final shouldUpdate =
+      final hasConflictTarget =
           onConflictColumns.every((column) => item[column] != null);
 
-      if (shouldUpdate) {
+      if (hasConflictTarget) {
         // Find the index for an item that matches all onConflictColumns
         final index = _database[tableKey]!.indexWhere((dbItem) =>
             onConflictColumns
                 .every((column) => dbItem[column] == item[column]));
 
         if (index != -1) {
+          if (ignoreDuplicates) {
+            continue;
+          }
           // Update the item in the database
           _database[tableKey]![index] = {
             ..._database[tableKey]![index],
             ...item
           };
-          return _database[tableKey]![index];
+          results.add(_database[tableKey]![index]);
+          continue;
         }
       }
       _database[tableKey]!.add(item);
-      return item;
-    }).toList();
+      results.add(item);
+    }
 
     return _createResponse(results, request: request);
   }

--- a/test/mock_supabase_http_client_test.dart
+++ b/test/mock_supabase_http_client_test.dart
@@ -104,6 +104,61 @@ void main() {
       expect(postsAfterUpdate.first, updatedData);
     });
 
+    test('Upsert with ignoreDuplicates leaves the conflicting row untouched',
+        () async {
+      const table = 'users';
+      await mockSupabase.from(table).insert({'id': 1, 'name': 'John Doe'});
+
+      await mockSupabase.from(table).upsert(
+        {'id': 1, 'name': 'James Bond'},
+        ignoreDuplicates: true,
+      );
+
+      final users = await mockSupabase.from(table).select();
+      expect(users.length, 1);
+      expect(users.first, {'id': 1, 'name': 'John Doe'});
+    });
+
+    test(
+        'Upsert with ignoreDuplicates and an onConflict column leaves the '
+        'conflicting row untouched', () async {
+      const table = 'users';
+      await mockSupabase.from(table).insert({'user_id': 1, 'name': 'John Doe'});
+
+      await mockSupabase.from(table).upsert(
+        {'user_id': 1, 'name': 'James Bond'},
+        onConflict: 'user_id',
+        ignoreDuplicates: true,
+      );
+
+      final users = await mockSupabase.from(table).select();
+      expect(users.length, 1);
+      expect(users.first, {'user_id': 1, 'name': 'John Doe'});
+    });
+
+    test('Upsert with ignoreDuplicates inserts non-conflicting rows', () async {
+      const table = 'users';
+      await mockSupabase.from(table).insert({'id': 1, 'name': 'John Doe'});
+
+      final inserted = await mockSupabase.from(table).upsert(
+        [
+          {'id': 1, 'name': 'James Bond'},
+          {'id': 2, 'name': 'Jane Doe'},
+        ],
+        ignoreDuplicates: true,
+      ).select();
+
+      expect(inserted, [
+        {'id': 2, 'name': 'Jane Doe'}
+      ]);
+      final users =
+          await mockSupabase.from(table).select().order('id', ascending: true);
+      expect(users, [
+        {'id': 1, 'name': 'John Doe'},
+        {'id': 2, 'name': 'Jane Doe'},
+      ]);
+    });
+
     test('Upsert then select', () async {
       // Test upserting a record
       await mockSupabase


### PR DESCRIPTION
Fixes #26

## Problem

`PostgrestQueryBuilder.upsert` sends `Prefer: resolution=ignore-duplicates` when called with `ignoreDuplicates: true`, and `resolution=merge-duplicates` otherwise. The request dispatch only recognized `merge-duplicates`, so an upsert with `ignoreDuplicates: true` was classified as `RequestType.insert` and never reached `_handleUpsert`. The conflicting row was appended as a duplicate:

```dart
await mockSupabase.from('users').insert({'id': 1, 'name': 'John Doe'});
await mockSupabase.from('users').upsert(
      {'id': 1, 'name': 'James Bond'},
      ignoreDuplicates: true,
    );
await mockSupabase.from('users').select();
// before: [{id: 1, name: John Doe}, {id: 1, name: James Bond}]
// after:  [{id: 1, name: John Doe}]
```

## Changes

- The `POST` dispatch now treats `resolution=ignore-duplicates` as an upsert alongside `resolution=merge-duplicates`. As a side effect, `postgrestExceptionTrigger` now receives `RequestType.upsert` rather than `RequestType.insert` for these requests, which is what it should have been.
- `_handleUpsert` reads the resolution from the `Prefer` header. When `ignore-duplicates` is requested, a row that matches the conflict target is left untouched and no new row is inserted. Rows that do not conflict are still inserted.
- Skipped rows are left out of the response body, matching what PostgREST returns for `INSERT ... ON CONFLICT DO NOTHING RETURNING`.

## Tests

Three tests were added covering both reproductions from the issue (default `id` conflict target and an explicit `onConflict` column) plus a mixed batch where one row conflicts and one does not, asserting both the response body and the resulting table contents. The full suite passes, and `dart format` and `dart analyze --fatal-warnings --fatal-infos` are clean.