### PR TITLE
fix: shape .single() responses after insert, update, upsert and delete

### DIFF
--- a/lib/src/mock_supabase_http_client.dart
+++ b/lib/src/mock_supabase_http_client.dart
@@ -378,12 +378,12 @@ class MockSupabaseHttpClient extends BaseClient {
 
     if (data is Map<String, dynamic>) {
       _database[tableKey]!.add(data);
-      return _createResponse([data], request: request);
+      return _createRowsResponse([data], request: request);
     } else if (data is List) {
       final List<Map<String, dynamic>> items =
           List<Map<String, dynamic>>.from(data);
       _database[tableKey]!.addAll(items);
-      return _createResponse(items, request: request);
+      return _createRowsResponse(items, request: request);
     } else {
       return _createResponse({'error': 'Invalid data format'},
           statusCode: 400, request: request);
@@ -412,7 +412,7 @@ class MockSupabaseHttpClient extends BaseClient {
     var updated = false;
 
     // Track updated rows
-    final updatedRows = [];
+    final updatedRows = <Map<String, dynamic>>[];
 
     // Update items that match the filters
     if (_database.containsKey(tableKey)) {
@@ -426,7 +426,7 @@ class MockSupabaseHttpClient extends BaseClient {
     }
 
     if (updated) {
-      return _createResponse(updatedRows, request: request);
+      return _createRowsResponse(updatedRows, request: request);
     } else {
       return _createResponse({'error': 'Not found'},
           statusCode: 404, request: request);
@@ -503,7 +503,7 @@ class MockSupabaseHttpClient extends BaseClient {
       return item;
     }).toList();
 
-    return _createResponse(results, request: request);
+    return _createRowsResponse(results, request: request);
   }
 
   StreamedResponse _handleDelete(
@@ -520,7 +520,7 @@ class MockSupabaseHttpClient extends BaseClient {
           statusCode: 400, request: request);
     }
 
-    List removedItems = [];
+    final removedItems = <Map<String, dynamic>>[];
     if (_database.containsKey(tableKey)) {
       _database[tableKey]!.removeWhere((row) {
         final matched = _matchesFilters(row: row, filters: queryParams);
@@ -531,7 +531,7 @@ class MockSupabaseHttpClient extends BaseClient {
       });
     }
 
-    return _createResponse(removedItems, request: request);
+    return _createRowsResponse(removedItems, request: request);
   }
 
   StreamedResponse _handleSelect(
@@ -543,7 +543,7 @@ class MockSupabaseHttpClient extends BaseClient {
     final tableKey = '$schema.$table';
     // Handle selecting data from the mock database
     if (!_database.containsKey(tableKey)) {
-      return _createResponse([], request: request);
+      return _createRowsResponse([], request: request);
     }
 
     var returningRows = List<Map<String, dynamic>>.from(_database[tableKey]!);
@@ -740,39 +740,14 @@ class MockSupabaseHttpClient extends BaseClient {
       final countType =
           preferHeader.contains('count=exact') ? 'exact' : 'planned';
 
-      return _createResponse(returningRows, request: request, headers: {
+      return _createRowsResponse(returningRows, request: request, headers: {
         'content-range': '$offset-${offset + returningRows.length}/$countValue',
         'content-profile': tableKey,
         'preference-applied': 'count=$countType'
       });
     }
 
-    // Handle single
-    if (request.headers['Accept'] == 'application/vnd.pgrst.object+json') {
-      if (returningRows.length == 1) {
-        return _createResponse(returningRows.first, request: request);
-      } else {
-        return _createResponse({
-          'error': '${returningRows.length} rows were found for single query'
-        }, request: request);
-      }
-    }
-
-    // Handle maybeSingle
-    if (request.headers['Accept'] == 'application/json') {
-      if (returningRows.isEmpty) {
-        return _createResponse(null, request: request);
-      } else if (returningRows.length == 1) {
-        return _createResponse(returningRows.first, request: request);
-      } else {
-        return _createResponse({
-          'error':
-              '${returningRows.length} rows were found for maybeSingle query'
-        }, statusCode: 405, request: request);
-      }
-    }
-
-    return _createResponse(returningRows, request: request);
+    return _createRowsResponse(returningRows, request: request);
   }
 
   StreamedResponse _handleHead(
@@ -832,6 +807,39 @@ class MockSupabaseHttpClient extends BaseClient {
         'content-profile': tableKey,
       },
       request: request,
+    );
+  }
+
+  /// Creates a response body shaped the way PostgREST would shape it for the
+  /// request's `Accept` header.
+  ///
+  /// A request made through `.single()` asks for
+  /// `application/vnd.pgrst.object+json`, which returns a single object rather
+  /// than a list, and fails with a 406 when the result does not contain
+  /// exactly one row.
+  StreamedResponse _createRowsResponse(
+    List<Map<String, dynamic>> rows, {
+    required BaseRequest request,
+    Map<String, String>? headers,
+  }) {
+    final accept = request.headers['Accept'] ?? '';
+    if (!accept.startsWith('application/vnd.pgrst.object+json')) {
+      return _createResponse(rows, request: request, headers: headers);
+    }
+    if (rows.length == 1) {
+      return _createResponse(rows.first, request: request, headers: headers);
+    }
+    return _createResponse(
+      {
+        'code': 'PGRST116',
+        'details': 'Results contain ${rows.length} rows, '
+            'application/vnd.pgrst.object+json requires 1 row',
+        'hint': null,
+        'message': 'JSON object requested, multiple (or no) rows returned',
+      },
+      statusCode: 406,
+      request: request,
+      headers: headers,
     );
   }
 

--- a/test/mock_supabase_http_client_test.dart
+++ b/test/mock_supabase_http_client_test.dart
@@ -729,6 +729,113 @@ void main() {
       expect(() => mockSupabase.from('posts').select().maybeSingle(),
           throwsException);
     });
+
+    test('Insert then single', () async {
+      final post = await mockSupabase
+          .from('posts')
+          .insert({'id': 1, 'title': 'First post'})
+          .select()
+          .single();
+      expect(post, {'id': 1, 'title': 'First post'});
+    });
+
+    test('Insert then maybeSingle', () async {
+      final post = await mockSupabase
+          .from('posts')
+          .insert({'id': 1, 'title': 'First post'})
+          .select()
+          .maybeSingle();
+      expect(post, {'id': 1, 'title': 'First post'});
+    });
+
+    test('Insert multiple rows then single throws', () async {
+      expect(
+        () => mockSupabase
+            .from('posts')
+            .insert([
+              {'id': 1, 'title': 'First post'},
+              {'id': 2, 'title': 'Second post'},
+            ])
+            .select()
+            .single(),
+        throwsA(isA<PostgrestException>()
+            .having((error) => error.code, 'code', 'PGRST116')),
+      );
+    });
+
+    test('Upsert then single', () async {
+      await mockSupabase.from('posts').insert({'id': 1, 'title': 'First post'});
+      final post = await mockSupabase
+          .from('posts')
+          .upsert({'id': 1, 'title': 'Updated post'})
+          .select()
+          .single();
+      expect(post, {'id': 1, 'title': 'Updated post'});
+    });
+
+    test('Update then single', () async {
+      await mockSupabase.from('posts').insert({'id': 1, 'title': 'First post'});
+      final post = await mockSupabase
+          .from('posts')
+          .update({'title': 'Updated post'})
+          .eq('id', 1)
+          .select()
+          .single();
+      expect(post, {'id': 1, 'title': 'Updated post'});
+    });
+
+    test('Delete then single', () async {
+      await mockSupabase.from('posts').insert({'id': 1, 'title': 'First post'});
+      final post = await mockSupabase
+          .from('posts')
+          .delete()
+          .eq('id', 1)
+          .select()
+          .single();
+      expect(post, {'id': 1, 'title': 'First post'});
+    });
+
+    test('Select single with no rows throws', () async {
+      expect(
+        () => mockSupabase.from('posts').select().single(),
+        throwsA(isA<PostgrestException>()
+            .having((error) => error.code, 'code', 'PGRST116')),
+      );
+    });
+
+    test('Delete with no match then maybeSingle returns null', () async {
+      await mockSupabase.from('posts').insert({'id': 1, 'title': 'First post'});
+      final post = await mockSupabase
+          .from('posts')
+          .delete()
+          .eq('id', 2)
+          .select()
+          .maybeSingle();
+      expect(post, null);
+    });
+
+    test('Single with count', () async {
+      await mockSupabase.from('posts').insert({'id': 1, 'title': 'First post'});
+      final response = await mockSupabase
+          .from('posts')
+          .select()
+          .single()
+          .count(CountOption.exact);
+      expect(response.data, {'id': 1, 'title': 'First post'});
+      expect(response.count, 1);
+    });
+
+    test('Select single with multiple rows throws', () async {
+      await mockSupabase.from('posts').insert([
+        {'id': 1, 'title': 'First post'},
+        {'id': 2, 'title': 'Second post'},
+      ]);
+      expect(
+        () => mockSupabase.from('posts').select().single(),
+        throwsA(isA<PostgrestException>()
+            .having((error) => error.code, 'code', 'PGRST116')),
+      );
+    });
   });
 
   group('Referenced table queries', () {


### PR DESCRIPTION
Closes #25

## What

`.single()` sets `Accept: application/vnd.pgrst.object+json`, and PostgREST answers that with a bare object instead of a list. The mock client only honored that header in the `GET` handler, so every mutation that returned rows still answered with a list:

```dart
await client.from('expenses').insert(row).select().single();
// type 'List<dynamic>' is not a subtype of type 'Map<dynamic, dynamic>'
```

The shaping now lives in a single `_createRowsResponse` helper that every handler returning rows goes through: insert, update, upsert, delete and select, including the count and empty-table paths.

## Error response for a non-single result

Previously a `.single()` matching zero or several rows answered `200` with `{'error': 'N rows were found for single query'}`, which the client happily returned as if it were the row. It now answers `406` with the body PostgREST sends:

```json
{
  "code": "PGRST116",
  "details": "Results contain 2 rows, application/vnd.pgrst.object+json requires 1 row",
  "hint": null,
  "message": "JSON object requested, multiple (or no) rows returned"
}
```

so `.single()` throws a `PostgrestException` and `.maybeSingle()` resolves to `null` on zero rows, matching a real project.

The separate `Accept: application/json` branch that used to shape `maybeSingle` on `GET` is gone. PostgREST returns a list for that media type, and postgrest-dart already narrows it client-side.

## Tests

Added cases for `.single()` and `.maybeSingle()` after insert, update, upsert and delete, for a single insert of several rows, for a select matching zero or several rows, and for `.single()` combined with `.count()`. The suite passes at 106 tests.