### PR TITLE
chore(release): publish 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.1.0
+
+- docs: mark this package as discontinued in favor of `supabase_test` once supabase_flutter v3 is released
+- fix: shape `.single()` responses after insert, update, upsert and delete [#29](https://github.com/supabase-community/mock_supabase_http_client/pull/29)
+- fix: honor `ignoreDuplicates` in upsert [#28](https://github.com/supabase-community/mock_supabase_http_client/pull/28)
+- docs: audit the current limitations list [#27](https://github.com/supabase-community/mock_supabase_http_client/pull/27)
+- fix(inFilter): enable inFilter usage with strings [#24](https://github.com/supabase-community/mock_supabase_http_client/pull/24)
+- fix: selecting with filter on empty table [#22](https://github.com/supabase-community/mock_supabase_http_client/pull/22)
+
 ## 0.0.3+2
 
 - fix: Error on select after delete or update [#17](https://github.com/supabase-community/mock_supabase_http_client/pull/17)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # MockSupabaseHttpClient
 
+> [!WARNING]
+> This package will be discontinued soon. Once version 3 of `supabase_flutter` is released, use the [`supabase_test`](https://pub.dev/packages/supabase_test) package instead.
+
 An mock http client for testing Supabase APIs.
 By passing the `MockSupabaseHttpClient` to the Supabase client, you can create a mock Supabase client that you can use for unit testing your Supabase API calls without making actual network requests.
 
@@ -30,7 +33,7 @@ final mockSupabase = SupabaseClient(
 Add mock_supabase_http_client to your dev dependencies:
 ```yaml
 dev_dependencies:
-  mock_supabase_http_client: ^0.0.1
+  mock_supabase_http_client: ^0.1.0
 ```
 
 ## Usage

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mock_supabase_http_client
 description: A mock Supabase client for testing API calls without making actual http requests for Dart/Flutter apps that use Supabase.
-version: 0.0.3+2
+version: 0.1.0
 homepage: 'https://supabase.com'
 repository: https://github.com/supabase-community/mock_supabase_http_client
 


### PR DESCRIPTION
## Summary
- Bump version to 0.1.0, rolling up the unreleased fixes since 0.0.3+2 (upsert ignoreDuplicates, single() shaping, inFilter strings, empty-table filtering) into the changelog
- Add a warning note to the top of the README that this package will soon be discontinued: once supabase_flutter v3 ships, use `supabase_test` instead

## Test plan
- [ ] CI (format, analyze, test) passes